### PR TITLE
fix: event logging webhook rate limits, losing events

### DIFF
--- a/events/guild_ban_add.go
+++ b/events/guild_ban_add.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/quackdiscord/bot/log"
 	"github.com/quackdiscord/bot/services"
 	"github.com/quackdiscord/bot/storage"
 	"github.com/quackdiscord/bot/structs"
@@ -80,6 +81,11 @@ func guildBanAddHandler(e services.Event) error {
 
 	err = utils.SendWHEmbed(settings.MemberWebhookURL, embed)
 	if err != nil {
+		log.Error().Err(err).Msg("Failed to send member ban add webhook, requeueing event after delay")
+		go func(ev services.Event) {
+			time.Sleep(60 * time.Second)
+			services.EQ.Enqueue(ev)
+		}(e)
 		return err
 	}
 

--- a/events/guild_ban_remove.go
+++ b/events/guild_ban_remove.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/quackdiscord/bot/log"
 	"github.com/quackdiscord/bot/services"
 	"github.com/quackdiscord/bot/storage"
 	"github.com/quackdiscord/bot/structs"
@@ -80,6 +81,11 @@ func guildBanRemoveHandler(e services.Event) error {
 
 	err = utils.SendWHEmbed(settings.MemberWebhookURL, embed)
 	if err != nil {
+		log.Error().Err(err).Msg("Failed to send member ban remove webhook, requeueing event after delay")
+		go func(ev services.Event) {
+			time.Sleep(60 * time.Second)
+			services.EQ.Enqueue(ev)
+		}(e)
 		return err
 	}
 

--- a/events/member_join.go
+++ b/events/member_join.go
@@ -77,8 +77,12 @@ func memberJoinHandler(e services.Event) error {
 
 	err = utils.SendWHEmbed(settings.MemberWebhookURL, embed)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to send member join webhook")
-		return nil
+		log.Error().Err(err).Msg("Failed to send memeber leave webhook, requeueing event after delay")
+		go func(ev services.Event) {
+			time.Sleep(60 * time.Second)
+			services.EQ.Enqueue(ev)
+		}(e)
+		return err
 	}
 
 	return nil

--- a/events/member_leave.go
+++ b/events/member_leave.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/quackdiscord/bot/log"
 	"github.com/quackdiscord/bot/services"
 	"github.com/quackdiscord/bot/storage"
 	"github.com/quackdiscord/bot/structs"
@@ -60,6 +61,11 @@ func memberLeaveHandler(e services.Event) error {
 
 	err = utils.SendWHEmbed(settings.MemberWebhookURL, embed)
 	if err != nil {
+		log.Error().Err(err).Msg("Failed to send member leave webhook, requeueing event after delay")
+		go func(ev services.Event) {
+			time.Sleep(60 * time.Second)
+			services.EQ.Enqueue(ev)
+		}(e)
 		return err
 	}
 

--- a/events/message_bulk_delete.go
+++ b/events/message_bulk_delete.go
@@ -92,8 +92,12 @@ func msgBulkDeleteHandler(e services.Event) error {
 
 	err = utils.SendWHEmbed(settings.MessageWebhookURL, embed)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to send message delete webhook")
-		return nil
+		log.Error().Err(err).Msg("Failed to send message bulk delete webhook, requeueing event after delay")
+		go func(ev services.Event) {
+			time.Sleep(60 * time.Second)
+			services.EQ.Enqueue(ev)
+		}(e)
+		return err
 	}
 
 	return nil

--- a/events/message_delete.go
+++ b/events/message_delete.go
@@ -83,8 +83,12 @@ func msgDeleteHandler(e services.Event) error {
 
 	err = utils.SendWHEmbed(settings.MessageWebhookURL, embed)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to send message delete webhook")
-		return nil
+		log.Error().Err(err).Msg("Failed to send message delete webhook, requeueing event after delay")
+		go func(ev services.Event) {
+			time.Sleep(60 * time.Second)
+			services.EQ.Enqueue(ev)
+		}(e)
+		return err
 	}
 
 	return nil

--- a/events/message_update.go
+++ b/events/message_update.go
@@ -76,8 +76,12 @@ func msgUpdateHandler(e services.Event) error {
 
 	err = utils.SendWHEmbed(settings.MessageWebhookURL, embed)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to send message edit webhook")
-		return nil
+		log.Error().Err(err).Msg("Failed to send message update webhook, requeueing event after delay")
+		go func(ev services.Event) {
+			time.Sleep(60 * time.Second)
+			services.EQ.Enqueue(ev)
+		}(e)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
closes #10 

Fixed the issue where when an event log would hit a webhook rate limit, the event in question would just be lost. Now, the event is re-queued after waiting 60 seconds. 

Note: this does not fix a service-wide rate limit, rather it just solves the issue of individual events being lost. If a specific event runs into multiple rate limits, it still will eventually be handled.